### PR TITLE
add support for i8 types

### DIFF
--- a/Network/XmlRpc/DTD_XMLRPC.hs
+++ b/Network/XmlRpc/DTD_XMLRPC.hs
@@ -8,6 +8,7 @@ import Text.XML.HaXml.Types (QName(..))
 {-Type decls-}
 
 newtype I4 = I4 String 		deriving (Eq,Show)
+newtype I8 = I8 String 		deriving (Eq,Show)
 newtype AInt = AInt String 		deriving (Eq,Show)
 newtype Boolean = Boolean String 		deriving (Eq,Show)
 newtype AString = AString String 		deriving (Eq,Show)
@@ -23,6 +24,7 @@ newtype Struct = Struct [Member] 		deriving (Eq,Show)
 newtype Value = Value [Value_] 		deriving (Eq,Show)
 data Value_ = Value_Str String
             | Value_I4 I4
+            | Value_I8 I8
             | Value_AInt AInt
             | Value_Boolean Boolean
             | Value_AString AString
@@ -54,6 +56,16 @@ instance XmlContent I4 where
         { e@(Elem _ [] _) <- element ["i4"]
         ; interior e $ return (I4) `apply` (text `onFail` return "")
         } `adjustErr` ("in <i4>, "++)
+
+instance HTypeable I8 where
+    toHType x = Defined "i8" [] []
+instance XmlContent I8 where
+    toContents (I8 a) =
+        [CElem (Elem (N "i8") [] (toText a)) ()]
+    parseContents = do
+        { e@(Elem _ [] _) <- element ["i8"]
+        ; interior e $ return (I8) `apply` (text `onFail` return "")
+        } `adjustErr` ("in <i8>, "++)
 
 instance HTypeable AInt where
     toHType x = Defined "int" [] []
@@ -182,6 +194,7 @@ instance HTypeable Value_ where
 instance XmlContent Value_ where
     toContents (Value_Str a) = toText a
     toContents (Value_I4 a) = toContents a
+    toContents (Value_I8 a) = toContents a
     toContents (Value_AInt a) = toContents a
     toContents (Value_Boolean a) = toContents a
     toContents (Value_AString a) = toContents a
@@ -193,6 +206,7 @@ instance XmlContent Value_ where
     parseContents = oneOf
         [ return (Value_Str) `apply` text
         , return (Value_I4) `apply` parseContents
+        , return (Value_I8) `apply` parseContents
         , return (Value_AInt) `apply` parseContents
         , return (Value_Boolean) `apply` parseContents
         , return (Value_AString) `apply` parseContents

--- a/Network/XmlRpc/Internals.hs
+++ b/Network/XmlRpc/Internals.hs
@@ -144,7 +144,7 @@ data MethodResponse = Return Value -- ^ A method response returning a value
 
 -- | An XML-RPC value.
 data Value =
-      ValueInt Int -- ^ int or i4
+      ValueInt Int -- ^ int, i4, or i8
     | ValueBool Bool -- ^ bool
     | ValueString String -- ^ string
     | ValueUnwrapped String -- ^ no inner element
@@ -432,6 +432,7 @@ fromXRValue (XR.Value vs)
   unstr (XR.Value_Str x)  = x
 
   f (XR.Value_I4 (XR.I4 x)) = liftM ValueInt (readInt x)
+  f (XR.Value_I8 (XR.I8 x)) = liftM ValueInt (readInt x)
   f (XR.Value_AInt (XR.AInt x)) = liftM ValueInt (readInt x)
   f (XR.Value_Boolean (XR.Boolean x)) = liftM ValueBool (readBool x)
   f (XR.Value_ADouble (XR.ADouble x)) = liftM ValueDouble (readDouble x)

--- a/xml-rpc.dtd
+++ b/xml-rpc.dtd
@@ -69,6 +69,10 @@
           (#PCDATA)>
 
 <!-- [+-]?[0-9]+ -->
+<!ELEMENT i8
+          (#PCDATA)>
+
+<!-- [+-]?[0-9]+ -->
 <!ELEMENT int
           (#PCDATA)>
 
@@ -122,7 +126,7 @@
 <!-- ******************* Parameter handling ******************* -->
 
 <!ELEMENT value
-          ( #PCDATA | i4 | int | boolean | string | dateTime.iso8601
+          ( #PCDATA | i4 | i8 | int | boolean | string | dateTime.iso8601
             | double | base64 | struct | array
             %v2values;
           )*


### PR DESCRIPTION
This is adds support for `i8` types --- 64-bit integers --- which some applications use in their responses. I needed this because the application I'm interfacing with uses `i8` types for every integer in its responses, and thought I would contribute it back.
