### PR TITLE
Accept unwrapped text as a String value.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+* 3000.10.3 (18 June 2014)
+
+  - Parse unwrapped text as a String value in accordance with the
+    XML-RPC spec.
+
 * 3000.10.2 (30 January 2014)
 
   - Adds support for i8 (64-bit integer) types: see new I8 type in

--- a/Network/XmlRpc/Internals.hs
+++ b/Network/XmlRpc/Internals.hs
@@ -267,6 +267,7 @@ instance XmlRpcType String where
     toValue = ValueString
     fromValue = simpleFromValue f
 	where f (ValueString x) = Just x
+              f (ValueUnwrapped x) = Just x
 	      f _ = Nothing
     getType _ = TString
 

--- a/haxr.cabal
+++ b/haxr.cabal
@@ -1,5 +1,5 @@
 Name: haxr
-Version: 3000.10.2
+Version: 3000.10.3
 Cabal-version: >=1.10
 Build-type: Simple
 Copyright: Bjorn Bringert, 2003-2006


### PR DESCRIPTION
The XML-RPC spec says that if no type is indicated for a value, then the
type is a string.

I had some code that was breaking when acting as a client of some C++ XML-RPC library because an empty string could be serialized as `<value></value>`. Ugh.
