### PR TITLE
Fix missing `network-uri` dependency in cabal file

### DIFF
--- a/haxr.cabal
+++ b/haxr.cabal
@@ -41,7 +41,8 @@ Library
                  array,
                  utf8-string,
                  template-haskell,
-                 blaze-builder >= 0.2 && < 0.4
+                 blaze-builder >= 0.2 && < 0.4,
+                 network-uri
   Exposed-Modules:
         Network.XmlRpc.Client,
         Network.XmlRpc.Server,


### PR DESCRIPTION
I was only able to do a `cabal install` after this fix...
