### PR TITLE
Empty URI port crash fix.

### DIFF
--- a/Network/XmlRpc/Client.hs
+++ b/Network/XmlRpc/Client.hs
@@ -164,7 +164,7 @@ post url headers content = do
 post_ :: URI -> URIAuth -> HeadersAList -> BSL.ByteString -> IO U.ByteString
 post_ uri auth headers content = withOpenSSL $ do
     let hostname = BS.pack (uriRegName auth)
-        port     = fromMaybe 443 (readMaybe $ tail $ uriPort auth)
+        port     = fromMaybe 443 (readMaybe $ tailSafe $ uriPort auth)
 
     c <- case init $ uriScheme uri of
         "http"  ->
@@ -224,3 +224,7 @@ request uri auth usrHeaders len = buildRequest $ do
 
 maybeFail :: Monad m => String -> Maybe a -> m a
 maybeFail msg = maybe (fail msg) return
+
+tailSafe :: [a] -> [a]
+tailSafe [] = []
+tailSafe x  = tail x

--- a/haxr.cabal
+++ b/haxr.cabal
@@ -1,5 +1,5 @@
 Name: haxr
-Version: 3000.11.1
+Version: 3000.11.2
 Cabal-version: >=1.10
 Build-type: Simple
 Copyright: Bjorn Bringert, 2003-2006


### PR DESCRIPTION
Fix for the issue https://github.com/byorgey/BlogLiterately/issues/22#issuecomment-123163552.

Added:
- safe tail for the URI port grab;