### PR TITLE
Generalize Remote instance

### DIFF
--- a/Network/XmlRpc/Client.hs
+++ b/Network/XmlRpc/Client.hs
@@ -39,6 +39,7 @@ module Network.XmlRpc.Client
 
 import           Network.XmlRpc.Internals
 
+import           Control.Monad.IO.Class
 import           Data.Functor               ((<$>))
 import           Data.Maybe
 import           Data.Int
@@ -132,8 +133,8 @@ class Remote a where
             -> ([Value] -> Err IO Value)
             -> a
 
-instance XmlRpcType a => Remote (IO a) where
-    remote_ h f = handleError (fail . h) $ f [] >>= fromValue
+instance (MonadIO m, XmlRpcType a) => Remote (m a) where
+    remote_ h f = liftIO . handleError (fail . h) $ f [] >>= fromValue
 
 instance (XmlRpcType a, Remote b) => Remote (a -> b) where
     remote_ h f x = remote_ h (\xs -> f (toValue x:xs))

--- a/haxr.cabal
+++ b/haxr.cabal
@@ -51,7 +51,8 @@ Library
                  array,
                  utf8-string,
                  template-haskell,
-                 blaze-builder >= 0.2 && < 0.5
+                 blaze-builder >= 0.2 && < 0.5,
+                 transformers
 
   if flag(network-uri)
     build-depends: network-uri >= 2.6, network >= 2.6


### PR DESCRIPTION
To allow constructs like

~~~ { .haskell }
authLogin :: String -> String -> ReaderT () IO String
authLogin = remote url "auth.login"

main = runReaderT (authLogin login pass) ()
~~~

instead of

~~~ { .haskell }
authLogin :: String -> String -> ReaderT () IO String
authLogin l p = liftIO $ remote url "auth.login" l p

main = runReaderT (authLogin login pass) ()
~~~

Code that I think can benefit from the change: <https://github.com/xkollar/spacewalk-api-hs/blob/master/src/Spacewalk/ApiInternal.hs>.