### PR TITLE
Added request value escaping for `>` to prevent breaking some XML-RPC Servers.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+* 3000.12.1.1
+
+  - `>` is now escaped as `&gt;` when sending requests. Without this
+    some XML-RPC servers will break when receiving an embedded CDATA section
+    (i.e. Atlassian Confluence).
+
 * 3000.11.1.1 (21 July 2015)
 
   - Bug fix: don't crash with empty URI port

--- a/Network/XmlRpc/Internals.hs
+++ b/Network/XmlRpc/Internals.hs
@@ -393,7 +393,7 @@ showBool b = if b then "1" else "0"
 
 -- escapes & and <
 showString :: String -> String
-showString s = replace "<" "&lt;" (replace "&" "&amp;" s)
+showString s = replace ">" "&gt;" $ replace "<" "&lt;" (replace "&" "&amp;" s)
 
 -- | Shows a double in signed decimal point notation.
 showDouble :: Double -> String

--- a/haxr.cabal
+++ b/haxr.cabal
@@ -1,5 +1,5 @@
 Name: haxr
-Version: 3000.11.1.1
+Version: 3000.12.1.1
 Cabal-version: >=1.10
 Build-type: Simple
 Copyright: Bjorn Bringert, 2003-2006


### PR DESCRIPTION
Atlassian Confluence XML-RPC server breaks when you try to send it an embedded CDATA section without the escaping. Python's `xmlrpclib` will also escape `>`.

I'm not sure whether this implementation is ideal (or whether this should be a parameter/argument that should be threaded through).

Example: when trying to send the string

    <ac:macro ac:name='html'><ac:plain-text-body><![CDATA[<h1>HELLO WORLD</h1>]]></ac:plain-text-body></ac:macro>

Python encodes it as the following (which Confluence server happily accepts):

    &lt;ac:macro ac:name='html'&gt;&lt;ac:plain-text-body&gt;&lt;![CDATA[&lt;h1&gt;HELLO WORLD&lt;/h1&gt;]]&gt;&lt;/ac:plain-text-body&gt;&lt;/ac:macro&gt;

HAXR currently encodes it as: 

    &lt;ac:macro ac:name='html'>&lt;ac:plain-text-body>&lt;![CDATA[&lt;h1>HELLO WORLD!&lt;/h1>]]>&lt;/ac:plain-text-body>&lt;/ac:macro>

This results in the following error being generated on the server:

    Fatal error parsing XML: org.xml.sax.SAXParseException; lineNumber: 3; columnNumber: 78; The character sequence "]]>" must not appear in content unless used to mark the end of a CDATA section.

I believe Haxr currently has support for doing the reverse escaping on decode (e.g. `&gt;` -> `>`) but doesn't do it on encode. This merely adds it to the encode.