### PR TITLE
.cabal: allow base-4.14

### DIFF
--- a/haxr.cabal
+++ b/haxr.cabal
@@ -33,7 +33,7 @@ flag network-uri
    default: True
 
 Library
-  Build-depends: base >= 4.9 && < 4.14,
+  Build-depends: base >= 4.9 && < 4.15,
                  base-compat >= 0.8 && < 0.12,
                  mtl,
                  mtl-compat,


### PR DESCRIPTION
allows building with ghc-8.10

(I usually just go with `base < 5` myself.)