### PR TITLE
Adapt to export changes in mtl-2.3

### DIFF
--- a/Network/XmlRpc/Internals.hs
+++ b/Network/XmlRpc/Internals.hs
@@ -48,9 +48,11 @@ Err, maybeToM, handleError, ioErrorToErr
 
 import           Control.Exception
 import           Control.Monad
-import           Control.Monad.Except
+import           Control.Monad.Except (ExceptT, MonadError(..), runExceptT)
 import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Fail (MonadFail)
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans
 import           Data.Char
 import           Data.List
 import           Data.Maybe

--- a/Network/XmlRpc/Server.hs
+++ b/Network/XmlRpc/Server.hs
@@ -32,7 +32,7 @@ import           Network.XmlRpc.Internals
 
 import qualified Codec.Binary.UTF8.String   as U
 import           Control.Exception
-import           Control.Monad.Except
+import           Control.Monad.Trans
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
 import           System.IO


### PR DESCRIPTION
In particular 'lift' and MonadIO is no longer re-exported, and a new identifier called handleError clashes with a locally defined one