### PR TITLE
allow base-4.19 for ghc 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,19 +28,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.4.7
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/haxr.cabal
+++ b/haxr.cabal
@@ -22,7 +22,7 @@ Extra-Source-Files:
         examples/test_client.hs       examples/test_server.hs       examples/time-xmlrpc-com.hs
         examples/validate.hs          examples/Makefile
 Bug-reports: https://github.com/byorgey/haxr/issues
-Tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.4 || ==9.6.1
+Tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.3
 
 Source-repository head
   type:     git

--- a/haxr.cabal
+++ b/haxr.cabal
@@ -33,7 +33,7 @@ flag network-uri
    default: True
 
 Library
-  Build-depends: base >= 4.9 && < 4.19,
+  Build-depends: base >= 4.9 && < 4.20,
                  base-compat >= 0.8 && < 0.14,
                  mtl < 2.4,
                  mtl-compat,


### PR DESCRIPTION
also updates CI to latest ghc versions